### PR TITLE
chore: add backlog scaffold for OpenClaw branch-first automation

### DIFF
--- a/backlog/EPICS/README.md
+++ b/backlog/EPICS/README.md
@@ -1,0 +1,3 @@
+# EPICS
+
+Create EPIC files here (EPIC-001.md, EPIC-002.md, ...).

--- a/backlog/GUIDELINES/README.md
+++ b/backlog/GUIDELINES/README.md
@@ -1,0 +1,3 @@
+# GUIDELINES
+
+Backlog conventions and execution rules.

--- a/backlog/MILESTONES/README.md
+++ b/backlog/MILESTONES/README.md
@@ -1,0 +1,3 @@
+# MILESTONES
+
+Track high-level milestones here.

--- a/backlog/README.md
+++ b/backlog/README.md
@@ -1,0 +1,12 @@
+# Backlog
+
+This repository backlog is managed for OpenClaw automation.
+
+## Rules
+- Agent changes must be implemented on feature branches only
+- No direct pushes to `main` or `master`
+- Open PR first, then review + merge
+
+## Intake
+- [ ] [AUTO] Add initial repository-specific backlog items
+- [ ] [AUTO-EXEC] Keep backlog current with pending work


### PR DESCRIPTION
## Summary
- Add `backlog/` scaffold (README, EPICS, MILESTONES, GUIDELINES)
- Enforce branch-first agent workflow (no direct main/master pushes)
- Enable repository context for automated backlog scanning/execution
