### PR TITLE
chore: add central governance workflow caller (wave 2)

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,10 @@
+name: Governance
+
+on:
+  pull_request:
+  push:
+    branches: [main, master, Main, "aiw/main"]
+
+jobs:
+  governance:
+    uses: Ai-Whisperers/ci-cd/.github/workflows/governance.yml@main


### PR DESCRIPTION
Adds reusable governance enforcement from `Ai-Whisperers/ci-cd`.